### PR TITLE
hide "press e to modify" hint when in the menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -390,7 +390,7 @@ Citizen.CreateThread(function()
 			local lastZone    = nil
 			if (PlayerData.job ~= nil and PlayerData.job.name == 'mechanic') or Config.IsMechanicJobOnly == false then
 				for k,v in pairs(Config.Zones) do
-					if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x then
+					if GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x and not lsMenuIsShowed then
 						isInLSMarker  = true
 						ESX.ShowHelpNotification(v.Hint)
 						break


### PR DESCRIPTION
This PR prevents the "Press E to modify" hint from showing while the menu is open. As soon as it's closed, it will show again.