### PR TITLE
[Critical] Cheatengine exploit closed!

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -39,11 +39,27 @@ end)
 
 RegisterServerEvent('esx_lscustom:refreshOwnedVehicle')
 AddEventHandler('esx_lscustom:refreshOwnedVehicle', function(myCar)
-	MySQL.Async.execute('UPDATE `owned_vehicles` SET `vehicle` = @vehicle WHERE `plate` = @plate',
-	{
-		['@plate']   = myCar.plate,
-		['@vehicle'] = json.encode(myCar)
-	})
+	local xPlayer = ESX.GetPlayerFromId(source)
+
+	MySQL.Async.fetchAll('SELECT * FROM owned_vehicles WHERE @plate = plate', {
+        ['@plate'] = myCar.plate
+    }, function(result)
+        if result[1] then
+            local vehicle = json.decode(result[1].vehicle)
+
+            if vehicle.model == myCar.model then
+
+                MySQL.Async.execute('UPDATE `owned_vehicles` SET `vehicle` = @vehicle WHERE `plate` = @plate',
+                    {
+                        ['@plate'] = myCar.plate,
+                        ['@vehicle'] = json.encode(myCar)
+                    })
+
+            else
+				print(('esx_lscustom: %s attempted to upgrade an vehicle with model mismatch!'):format(xPlayer.identifier))
+			end
+        end
+    end)
 end)
 
 ESX.RegisterServerCallback('esx_lscustom:getVehiclesPrices', function(source, cb)


### PR DESCRIPTION
Closes a hole in lscustoms, that allows cheatengine users to change anycar in to anycar as long as they got the hash id of there current vehicle and there new vehicle.