### PR TITLE
Add support for dashboard & interior color

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -194,7 +194,7 @@ function GetAction(data)
 					table.insert(elements, {label = " " .. _U('by_default'), modType = k, modNum = false})
 				elseif v.modType == 'neonColor' or v.modType == 'tyreSmokeColor' then -- disable neon
 					table.insert(elements, {label = " " ..  _U('by_default'), modType = k, modNum = {0, 0, 0}})
-				elseif v.modType == 'color1' or v.modType == 'color2' or v.modType == 'pearlescentColor' or v.modType == 'wheelColor' then
+				elseif v.modType == 'color1' or v.modType == 'color2' or v.modType == 'pearlescentColor' or v.modType == 'dashboardColor' or v.modType == 'interiorColor' or v.modType == 'wheelColor' then
 					local num = myCar[v.modType]
 					table.insert(elements, {label = " " .. _U('by_default'), modType = k, modNum = num})
 				elseif v.modType == 17 then
@@ -244,7 +244,7 @@ function GetAction(data)
 							modNum = { neons[i].r, neons[i].g, neons[i].b }
 						})
 					end
-				elseif v.modType == 'color1' or v.modType == 'color2' or v.modType == 'pearlescentColor' or v.modType == 'wheelColor' then -- RESPRAYS
+				elseif v.modType == 'color1' or v.modType == 'color2' or v.modType == 'pearlescentColor' or v.modType == 'dashboardColor' or v.modType == 'interiorColor' or v.modType == 'wheelColor' then -- RESPRAYS
 					local colors = GetColors(data.color)
 					for j = 1, #colors, 1 do
 						local _label = ''
@@ -323,7 +323,7 @@ function GetAction(data)
 					end
 				end
 			else
-				if data.value == 'primaryRespray' or data.value == 'secondaryRespray' or data.value == 'pearlescentRespray' or data.value == 'modFrontWheelsColor' then
+				if data.value == 'primaryRespray' or data.value == 'secondaryRespray' or data.value == 'pearlescentRespray' or data.value == 'dashboardRespray' or data.value == 'interiorRespray' or data.value == 'modFrontWheelsColor' then
 					for i=1, #Config.Colors, 1 do
 						if data.value == 'primaryRespray' then
 							table.insert(elements, {label = Config.Colors[i].label, value = 'color1', color = Config.Colors[i].value})
@@ -331,6 +331,10 @@ function GetAction(data)
 							table.insert(elements, {label = Config.Colors[i].label, value = 'color2', color = Config.Colors[i].value})
 						elseif data.value == 'pearlescentRespray' then
 							table.insert(elements, {label = Config.Colors[i].label, value = 'pearlescentColor', color = Config.Colors[i].value})
+						elseif data.value == 'dashboardRespray' then
+							table.insert(elements, {label = Config.Colors[i].label, value = 'dashboardColor', color = Config.Colors[i].value})
+						elseif data.value == 'interiorRespray' then
+							table.insert(elements, {label = Config.Colors[i].label, value = 'interiorColor', color = Config.Colors[i].value})
 						elseif data.value == 'modFrontWheelsColor' then
 							table.insert(elements, {label = Config.Colors[i].label, value = 'wheelColor', color = Config.Colors[i].value})
 						end

--- a/config.lua
+++ b/config.lua
@@ -764,6 +764,8 @@ Config.Menus = {
 		primaryRespray = _U('primary'),
 		secondaryRespray = _U('secondary'),
 		pearlescentRespray = _U('pearlescent'),
+		dashboardRespray = _U('dashboard'),
+		interiorRespray = _U('interior'),
 	},
 	primaryRespray = {
 		label = _U('primary'),
@@ -775,6 +777,14 @@ Config.Menus = {
 	},
 	pearlescentRespray = {
 		label = _U('pearlescent'),
+		parent = 'resprays',
+	},
+	dashboardRespray = {
+		label = _U('dashboard'),
+		parent = 'resprays',
+	},
+	interiorRespray = {
+		label = _U('interior'),
 		parent = 'resprays',
 	},
 	color1 = {
@@ -794,6 +804,18 @@ Config.Menus = {
 		parent = 'pearlescentRespray',
 		modType = 'pearlescentColor',
 		price = 0.88
+	},
+	dashboardColor = {
+		label = _U('dashboard'),
+		parent = 'dashboardRespray',
+		modType = 'dashboardColor',
+		price = 0.66
+	},
+	interiorColor = {
+		label = _U('interior'),
+		parent = 'interiorRespray',
+		modType = 'interiorColor',
+		price = 0.66
 	},
 	modXenon = {
 		label = _U('headlights'),

--- a/locales/br.lua
+++ b/locales/br.lua
@@ -222,6 +222,8 @@ Locales['br'] = {
   ['primary'] = 'primário',
   ['secondary'] = 'secundário',
   ['pearlescent'] = 'perolado',
+  ['dashboard'] = 'painel',
+  ['interior'] = 'interior',
   -- Misc
   ['headlights'] = 'faróis dianteiros',
   ['licenseplates'] = 'matricula',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -222,6 +222,8 @@ Locales['en'] = {
   ['primary'] = 'primary',
   ['secondary'] = 'secondary',
   ['pearlescent'] = 'pearlescent',
+  ['dashboard'] = 'dashboard',
+  ['interior'] = 'interior',
   -- Misc
   ['headlights'] = 'headlights',
   ['licenseplates'] = 'license Plate',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -222,6 +222,8 @@ Locales['fr'] = {
   ['primary'] = 'primaire',
   ['secondary'] = 'secondaire',
   ['pearlescent'] = 'nacré',
+  ['dashboard'] = 'tableau de bord',
+  ['interior'] = 'intérieur',
   -- Misc
   ['headlights'] = 'phares',
   ['licenseplates'] = 'plaque',

--- a/locales/pl.lua
+++ b/locales/pl.lua
@@ -222,6 +222,8 @@ Locales['pl'] = {
   ['primary'] = 'pierwszy',
   ['secondary'] = 'drugi',
   ['pearlescent'] = 'perła',
+  ['dashboard'] = 'deska rozdzielcza',
+  ['interior'] = 'wnętrze',
   -- Misc
   ['headlights'] = 'reflektory',
   ['licenseplates'] = 'tablice rejestracyjne',


### PR DESCRIPTION
Adds the ability to customize the dashboard and interior color of vehicles.

PR (https://github.com/ESX-Org/es_extended/pull/349) adds support for [SetVehicleDashboardColour](https://runtime.fivem.net/doc/natives/#_0x6089CDF6A57F326C) and [SetVehicleInteriorColour](https://runtime.fivem.net/doc/natives/#_0xF40DD601A65F7F19)

Edit - Added Image for more context
![20191001191839_1](https://user-images.githubusercontent.com/10443061/65945248-12012800-e490-11e9-8aa8-7b0688d8db7c.jpg)
